### PR TITLE
add option to preserve tracker object

### DIFF
--- a/carbontracker/tracker.py
+++ b/carbontracker/tracker.py
@@ -261,7 +261,7 @@ class CarbonTracker:
         except Exception as e:
             self._handle_error(e)
 
-    def epoch_end(self):
+    def epoch_end(self, manual_delete=False):
         if self.deleted:
             return
 
@@ -276,7 +276,7 @@ class CarbonTracker:
                 if self.stop_and_confirm:
                     self._user_query()
 
-            if self.epoch_counter == self.monitor_epochs:
+            if self.epoch_counter == self.monitor_epochs and not manual_delete:
                 self._delete()
         except Exception as e:
             self._handle_error(e)


### PR DESCRIPTION
Add an option to epoch_end to avoid the tracker object being deleted, so it can be accessed programmatically for extraction of e.g. runtime, energy usage, and CO2 even after the last epoch has finished.