### PR TITLE
Added Python 3.8-3.11 in CI test setup, and fixed several version-related bugs.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.8','3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v3

--- a/carbontracker/components/gpu/nvidia.py
+++ b/carbontracker/components/gpu/nvidia.py
@@ -29,8 +29,8 @@ class NvidiaGPU(Handler):
         names = [pynvml.nvmlDeviceGetName(handle) for handle in self._handles]
 
         # Decode names if Python version is less than 3.9
-        if sys.version_info < (3, 9):
-            names = [name.decode("utf-8") for name in names]
+        if sys.version_info < (3,10):
+            names = [name.decode() for name in names]
 
         return names
 

--- a/carbontracker/emissions/intensity/intensity.py
+++ b/carbontracker/emissions/intensity/intensity.py
@@ -2,9 +2,9 @@ import os.path
 import traceback
 
 import geocoder
-import importlib.resources
 import numpy as np
 import pandas as pd
+import sys
 
 from carbontracker import loggerutil
 from carbontracker import exceptions
@@ -26,8 +26,14 @@ def get_default_intensity():
         country = "Unknown"
 
     try:
-        carbon_intensities_df = pd.read_csv(
-            str(importlib.resources.files("carbontracker").joinpath("data", "carbon-intensities.csv")))
+        # importlib.resources.files was introduced in Python 3.9
+        if sys.version_info < (3,9):
+            import pkg_resources
+            path = pkg_resources.resource_filename("carbontracker", "data/carbon-intensities.csv")
+        else:
+            import importlib.resources
+            path = importlib.resources.files("carbontracker").joinpath("data", "carbon-intensities.csv")
+        carbon_intensities_df = pd.read_csv(str(path))
         intensity_row = carbon_intensities_df[carbon_intensities_df["alpha-2"] == country].iloc[0]
         intensity = intensity_row["Carbon intensity of electricity (gCO2/kWh)"]
         year = intensity_row["Year"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ dynamic = ["version"]
 homepage = "https://github.com/lfwa/carbontracker"
 repository = "https://github.com/lfwa/carbontracker"
 
+[tool.setuptools]
+packages = ['carbontracker']
+
 [tool.setuptools_scm]
 
 [project.optional-dependencies]

--- a/tests/intensity/test_intensity.py
+++ b/tests/intensity/test_intensity.py
@@ -3,7 +3,7 @@ import unittest
 from unittest.mock import patch, MagicMock
 import numpy as np
 import pandas as pd
-import importlib.resources
+import sys
 
 from carbontracker import constants
 from carbontracker.emissions.intensity import intensity
@@ -21,9 +21,16 @@ class TestIntensity(unittest.TestCase):
         mock_geocoder_ip.return_value = mock_location
 
         result = intensity.get_default_intensity()
-        ref = importlib.resources.files("carbontracker") / "data/carbon-intensities.csv"
-        with importlib.resources.as_file(ref) as path:
-            carbon_intensities_df = pd.read_csv(path)
+
+        # importlib.resources.files was introduced in Python 3.9 and replaces deprecated pkg_resource.resources
+        if sys.version_info < (3,9):
+            import pkg_resources
+            carbon_intensities_df = pd.read_csv(pkg_resources.resource_filename("carbontracker", "data/carbon-intensities.csv"))
+        else:
+            import importlib.resources
+            ref = importlib.resources.files("carbontracker") / "data/carbon-intensities.csv"
+            with importlib.resources.as_file(ref) as path:
+                carbon_intensities_df = pd.read_csv(path)
         intensity_row = carbon_intensities_df[carbon_intensities_df["alpha-2"] == mock_location.country].iloc[0]
         expected_intensity = intensity_row["Carbon intensity of electricity (gCO2/kWh)"]
 

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -147,6 +147,8 @@ class TestCarbonTrackerThread(unittest.TestCase):
         self.thread.stop()
 
         self.assertFalse(self.thread.running)
+
+        # assert_any_call because different log statements races in Python 3.11 in Github Actions
         self.mock_logger.info.assert_any_call("Monitoring thread ended.")
         self.mock_logger.output.assert_called_with("Finished monitoring.", verbose_level=1)
 

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -147,7 +147,7 @@ class TestCarbonTrackerThread(unittest.TestCase):
         self.thread.stop()
 
         self.assertFalse(self.thread.running)
-        self.mock_logger.info.assert_called_with("Monitoring thread ended.")
+        self.mock_logger.info.assert_any_call("Monitoring thread ended.")
         self.mock_logger.output.assert_called_with("Finished monitoring.", verbose_level=1)
 
     def test_stop_tracker_not_running(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 isolated_build = True
-envlist = py38, py39, py310
-
+envlist = py38, py39, py310, py311, py312
+ 
 [testenv]
+deps=pyfakefs
 commands =
-    python -m unittest discover
+    python -m unittest {posargs}


### PR DESCRIPTION
**Changelog**

- **minor breaking change:** Improved NvidiaGPU.devices() such that it now always returns a unicode string, instead of a binary string in Python 3.8-3.9 and a unicode string in Python 3.10+.
- Improves `tox.ini`, so one now can run `tox` for testing everything using test discovery, or `tox -e py11 -- -k "test_case_search_string"` for testing a specific test using a specific Python version
- Improved `pyproject.toml` such that `logs/` and `test_logs/` directories will not get detected as package folders. These directories are not checked in Git, but appears during testing. This just means that one does not have to run `rm -rf logs/ test_logs/` between test runs.
- Added Python 3.8-3.11 to Github Actions test matrix for improved compatibility with supported Python versions.
- Made version specific usage of either `pkg_resources` or `importlib` depending on Python version.
- Fixed test depending on logging race condition.