### PR TITLE
[Bug Fix] CarbonTrackerThread Indefinite blocking

### DIFF
--- a/carbontracker/tracker.py
+++ b/carbontracker/tracker.py
@@ -158,6 +158,7 @@ class CarbonTrackerThread(Thread):
             return
 
         self.running = False
+        self.measuring_event.set() # Set the event to ensure the thread can exit if waiting
         self.logger.info("Monitoring thread ended.")
         self.logger.output("Finished monitoring.", verbose_level=1)
 


### PR DESCRIPTION
## Issue

`CarbonTrackerThread` can remain alive indefinitely after calling `tracker.stop()`.

This happens when the thread is blocked on `measuring_event.wait()`. The `stop()` method sets `self.running = False`, but does not wake the waiting thread. As a result, the thread never reaches the loop condition ([Link to loop condition](https://github.com/pietrotrope/carbontracker/blob/94219fd329a60ef54fee0c71cd415702091ad0e3/carbontracker/tracker.py#L138)) again and cannot terminate.

## How to reproduce

The issue can be easily reproduced in two cases:

1. Start a tracker and stop it without starting any epoch:

```python
tracker = CarbonTracker(...)
tracker.stop()
```

2. Stop the tracker some time after an epoch has finished instead of immediately (for example, after a delay simulating additional user operations before calling `tracker.stop()`). After the final measurement is completed, the monitoring thread returns to waiting on `measuring_event`. Calling `tracker.stop()` at this point leaves the thread blocked indefinitely.

```python
tracker = CarbonTracker(epochs=2)

tracker.epoch_start()
tracker.epoch_end()

import time
time.sleep(2)

tracker.stop()
```

In both cases, the active threads can be inspected before and after stopping the tracker:

```python
import threading
for t in threading.enumerate():
    print(t.name, t.is_alive())
```

Before calling `tracker.stop()`, both `CarbonTrackerThread` and `CarbonIntensityThread` should be visible in the output.

After calling `tracker.stop()` without the fix, the `CarbonTrackerThread` remains alive (indefinitely).

## Fix

Wake the monitoring thread when stopping it by setting `measuring_event` after updating `self.running`:

```python
    def stop(self):
        if not self.running:
            return

        self.running = False
        self.measuring_event.set() # NEW INSTRUCTION: Set the event to ensure the thread can exit if waiting
        self.logger.info("Monitoring thread ended.")
        self.logger.output("Finished monitoring.", verbose_level=1)
```

This allows the thread to resume execution, evaluate `self.running`, and exit normally.

After applying this fix, `CarbonTrackerThread` no longer remains active after calling `tracker.stop()` in the above scenarios.